### PR TITLE
[버그 픽스] 경매 시간, 경매 총 개수, 토큰 유효 시간 연장 관련 이슈 수정

### DIFF
--- a/app/api/v1/endpoints/admin_products.py
+++ b/app/api/v1/endpoints/admin_products.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
 from typing import List, Optional
+from app.core.auth_deps import require_admin
 from app.domains.common.error_response import BusinessErrorResponse, ServerErrorResponse
 from app.domains.common.paging import Page
 
@@ -21,7 +22,7 @@ def get_product_service(db: Session = Depends(get_db)) -> ProductAdminService:
 
 class AdminProductsAPI:
     def __init__(self):
-        self.router = APIRouter()
+        self.router = APIRouter(dependencies=[Depends(require_admin)])
 
         @self.router.get(
             "",

--- a/app/api/v1/endpoints/admin_stores.py
+++ b/app/api/v1/endpoints/admin_stores.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
 from typing import List, Optional
+from app.core.auth_deps import require_admin
 from app.domains.common.error_response import BusinessErrorResponse, ServerErrorResponse
 from app.domains.common.paging import Page
 
@@ -17,7 +18,7 @@ def get_product_service(db: Session = Depends(get_db)) -> ProductAdminService:
 
 class AdminStoresAPI:
     def __init__(self):
-        self.router = APIRouter()
+        self.router = APIRouter(dependencies=[Depends(require_admin)])
 
         @self.router.get(
             "",

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     # JWT
     SECRET_KEY: str = "change-me"  # set in .env for prod
     ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24
 
     # Google OAuth
     GOOGLE_CLIENT_ID: str = ""

--- a/app/domains/auctions/admin_service.py
+++ b/app/domains/auctions/admin_service.py
@@ -107,7 +107,8 @@ class AuctionAdminService:
             now_utc = datetime.now(timezone.utc)
             # Normalize DB datetimes to timezone-aware (assume UTC if naive)
             if target.starts_at.tzinfo is None:
-                starts_at = self._parse_kst_to_utc(target.starts_at.isoformat())
+                # If starts_at is naive, assume UTC
+                starts_at = target.starts_at.replace(tzinfo=timezone.utc)
             if not (target.status == AuctionStatus.SCHEDULED.value and now_utc < starts_at):
                 raise BusinessError(
                     ErrorCode.INVALID_AUCTION_STATUS,

--- a/app/domains/auctions/mappers.py
+++ b/app/domains/auctions/mappers.py
@@ -1,10 +1,14 @@
 from typing import Iterable, List
+from app.core.repository_mixins import TimezoneConversionMixin
 from app.domains.auctions.auction_info import AuctionInfo
 from app.domains.auctions.bid_item import BidItem, UserBrief
 
 
 def row_to_auction_info(row) -> AuctionInfo:
-    m = row._mapping if hasattr(row, "_mapping") else row
+    timezone_converter = TimezoneConversionMixin()
+    
+    r = row._mapping if hasattr(row, "_mapping") else row
+    m = timezone_converter.convert_row_datetimes(r)
     return AuctionInfo(
         auction_id=m["id"],
         buy_now_price=(

--- a/app/repositories/auction_admin_read.py
+++ b/app/repositories/auction_admin_read.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Tuple
 from sqlalchemy.orm import Session
 from sqlalchemy import select, func, desc, and_, or_, exists
+from app.core.timezone import utc_to_kst
 from app.schemas.auctions import Auction, Bid
 from app.schemas.products import Product, ProductImage
 from app.schemas.stores import PopupStore
@@ -256,8 +257,8 @@ class AuctionAdminReadRepository:
                     product_name=str(r.product_name),
                     start_price=float(r.start_price),
                     buy_now_price=float(r.buy_now_price) if r.buy_now_price is not None else None,
-                    starts_at=r.starts_at.isoformat(),
-                    ends_at=r.ends_at.isoformat(),
+                    starts_at=utc_to_kst(r.starts_at).isoformat(),
+                    ends_at=utc_to_kst(r.ends_at).isoformat(),
                     status=str(r.status),
                     payment_status=payment_ko,
                     shipment_status=shipment_ko,
@@ -368,8 +369,8 @@ class AuctionAdminReadRepository:
             min_bid_price=float(r.min_bid_price),
             buy_now_price=float(r.buy_now_price) if r.buy_now_price is not None else None,
             deposit_amount=float(r.deposit_amount),
-            starts_at=r.starts_at.isoformat(),
-            ends_at=r.ends_at.isoformat(),
+            starts_at=utc_to_kst(r.starts_at).isoformat(),
+            ends_at=utc_to_kst(r.ends_at).isoformat(),
             status=str(r.status),
             current_highest_bid=float(r.current_highest_bid) if r.current_highest_bid is not None else None,
             bidder_count=int(r.bidder_count),

--- a/app/repositories/auction_admin_read.py
+++ b/app/repositories/auction_admin_read.py
@@ -178,7 +178,8 @@ class AuctionAdminReadRepository:
         else:
             stmt = stmt.order_by(Auction.starts_at.desc())
 
-        count_stmt = select(func.count(Auction.id)).select_from(Auction)
+        # 필터링된 total을 위해 기존 stmt를 이용해 count stmt 생성
+        count_stmt = stmt.with_only_columns(func.count(Auction.id))
         items_rows = self.db.execute(stmt.limit(size).offset((page - 1) * size)).all()
         total = int(self.db.execute(count_stmt).scalar_one())
 


### PR DESCRIPTION
### 주요 수정 사항
- 백오피스 스토어/상품 조회에 require_admin을 추가했습니다.
- admin 경매 목록 조회에서 필터 적용 후에도 필터 적용 전 total을 반환하는 문제를 해결했습니다.
- 테스트 시 토큰만료로 데이터를 못받는 상황을 고려해 토큰 만료 시간을 하루로 변경했습니다.
- 유저/백오피스에서 조회하는 경매 시간을 모두 kst로 통일하였습니다. 